### PR TITLE
fix(deps): Revert bump spring-boot to version 3.2.0

### DIFF
--- a/customer-onboarding-showcase/pom.xml
+++ b/customer-onboarding-showcase/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.2.0</spring.boot.version>
+        <spring.boot.version>3.1.5</spring.boot.version>
         <camunda7.version>7.20.0</camunda7.version>
         <camunda8.version>8.1.4</camunda8.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>

--- a/miranum-stack-showcase/pom.xml
+++ b/miranum-stack-showcase/pom.xml
@@ -17,7 +17,7 @@
         <miranum.version>0.4.0</miranum.version>
         <camunda7.version>7.20.0</camunda7.version>
         <lombok.version>1.18.30</lombok.version>
-        <spring.boot.version>3.2.0</spring.boot.version>
+        <spring.boot.version>3.1.5</spring.boot.version>
         <maven.surfire.plugin.version>3.2.2</maven.surfire.plugin.version>
     </properties>
 

--- a/pizza-order-showcase/pom.xml
+++ b/pizza-order-showcase/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.2.0</spring.boot.version>
+        <spring.boot.version>3.1.5</spring.boot.version>
         <camunda7.version>7.20.0</camunda7.version>
         <camunda8.version>8.3.1</camunda8.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>

--- a/process-example/pom.xml
+++ b/process-example/pom.xml
@@ -21,7 +21,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.2.0</spring.boot.version>
+        <spring.boot.version>3.1.5</spring.boot.version>
         <camunda7.version>7.20.0</camunda7.version>
         <camunda8.version>8.3.1</camunda8.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>

--- a/restaurant-showcase/pom.xml
+++ b/restaurant-showcase/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
-        <spring.boot.version>3.2.0</spring.boot.version>
+        <spring.boot.version>3.1.5</spring.boot.version>
         <camunda7.version>7.18.0</camunda7.version>
         <camunda8.version>8.3.1</camunda8.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>

--- a/schema-client-example/pom.xml
+++ b/schema-client-example/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>3.2.0</spring.boot.version>
+        <spring.boot.version>3.1.5</spring.boot.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <lombok.version>1.18.30</lombok.version>
         <miranum.version>0.4.0</miranum.version>


### PR DESCRIPTION
This reverts commit b749e1948309d774385e3cc3d7d599674f80f958.

**Issue**
Spring Boot Version 3.2.0 led to certain side effects with using Zeebe. 
Hence I am reverting the commit. 

**Description**
Revert update to Spring Boot 3.2.0 -> using 3.1.5 instead

